### PR TITLE
Fleet fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ website/vendor
 *.winfile eol=crlf
 /.vs
 node_modules
+
+
+go.sum

--- a/appstream/resource_fleet.go
+++ b/appstream/resource_fleet.go
@@ -75,10 +75,11 @@ func resourceAppstreamFleet() *schema.Resource {
                 Type:         schema.TypeString,
                 Optional:     true,
             },
-
-            "image_name": {
+			
+			"image_arn": {
                 Type:         schema.TypeString,
-                Required:     true,
+				Required:     true,
+				ForceNew:	  true,
             },
 
             "instance_type": {
@@ -185,9 +186,10 @@ func resourceAppstreamFleetCreate(d *schema.ResourceData, meta interface{}) erro
 		CreateFleetInputOpts.FleetType = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("image_name"); ok {
-		CreateFleetInputOpts.ImageName = aws.String(v.(string))
+	if v, ok := d.GetOk("image_arn"); ok {
+		CreateFleetInputOpts.ImageArn = aws.String(v.(string))
 	}
+
 
 	if v, ok := d.GetOk("instance_type"); ok {
 		CreateFleetInputOpts.InstanceType = aws.String(v.(string))
@@ -347,7 +349,7 @@ func resourceAppstreamFleetRead(d *schema.ResourceData, meta interface{}) error 
 			d.Set("disconnect_timeout", v.DisconnectTimeoutInSeconds)
 			d.Set("enable_default_internet_access", v.EnableDefaultInternetAccess)
 			d.Set("fleet_type", v.FleetType)
-			d.Set("image_name", v.ImageName)
+			d.Set("image_arn", v.ImageArn)
 			d.Set("instance_type", v.InstanceType)
 			d.Set("max_user_duration", v.MaxUserDurationInSeconds)
 
@@ -402,7 +404,7 @@ func resourceAppstreamFleetUpdate(d *schema.ResourceData, meta interface{}) erro
     }
 
     if d.HasChange("description") {
-        d.SetPartial("description")
+    	d.SetPartial("description")
         log.Printf("[DEBUG] Modify Fleet")
         description :=d.Get("description").(string)
         UpdateFleetInputOpts.Description = aws.String(description)
@@ -422,11 +424,11 @@ func resourceAppstreamFleetUpdate(d *schema.ResourceData, meta interface{}) erro
         UpdateFleetInputOpts.DisplayName = aws.String(display_name)
     }
 
-    if d.HasChange("image_name") {
-        d.SetPartial("image_name")
+	if d.HasChange("image_arn") {
+        d.SetPartial("image_arn")
         log.Printf("[DEBUG] Modify Fleet")
-        image_name :=d.Get("image_name").(string)
-        UpdateFleetInputOpts.ImageName = aws.String(image_name)
+        image_arn :=d.Get("image_arn").(string)
+        UpdateFleetInputOpts.ImageArn = aws.String(image_arn)
     }
 
     if d.HasChange("instance_type") {

--- a/appstream/resource_image_builder.go
+++ b/appstream/resource_image_builder.go
@@ -64,6 +64,7 @@ func resourceAppstreamImageBuilder() *schema.Resource {
             "image_arn": {
                 Type:         schema.TypeString,
                 Required:     true,
+                ForceNew:	  true,
             },
 
             "instance_type": {

--- a/appstream/resource_image_builder.go
+++ b/appstream/resource_image_builder.go
@@ -61,7 +61,7 @@ func resourceAppstreamImageBuilder() *schema.Resource {
                 Optional:     true,
             },
 
-            "image_name": {
+            "image_arn": {
                 Type:         schema.TypeString,
                 Required:     true,
             },
@@ -136,8 +136,8 @@ func resourceAppstreamImageBuilderCreate(d *schema.ResourceData, meta interface{
         CreateImageBuilderInputOpts.EnableDefaultInternetAccess = aws.Bool(v.(bool))
     }
 
-    if v, ok := d.GetOk("image_name"); ok {
-        CreateImageBuilderInputOpts.ImageName = aws.String(v.(string))
+    if v, ok := d.GetOk("image_arn"); ok {
+        CreateImageBuilderInputOpts.ImageArn = aws.String(v.(string))
     }
 
     if v, ok := d.GetOk("instance_type"); ok {
@@ -226,7 +226,7 @@ func resourceAppstreamImageBuilderRead(d *schema.ResourceData, meta interface{})
             d.Set("appstream_agent_version", v.AppstreamAgentVersion)
             d.Set("enable_default_internet_access", v.EnableDefaultInternetAccess)
             d.Set("instance_type", v.InstanceType)
-            d.Set("image_name", d.Get("image_name"))
+            d.Set("image_arn", d.Get("image_arn"))
             d.Set("state", v.State)
             if v.VpcConfig != nil {
                 vpc_attr := map[string]interface{}{}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/aws/aws-sdk-go v1.30.19
 	github.com/hashicorp/aws-sdk-go-base v0.4.0
-	github.com/hashicorp/terraform v0.12.24
+	github.com/hashicorp/terraform v0.12.25
 	github.com/hashicorp/terraform-plugin-sdk v1.11.0
 	github.com/mitchellh/go-homedir v1.1.0
 )


### PR DESCRIPTION
Due to aws api limitation, `image_name `cant be used for cross account image reference. This PR will replace it with `image_arn`, which can be used for public/private/shared images.

`image_arn` cant be changed so it has `ForceNew = true` attribute.

I also bumped terraform lib version to 0.12.25, since we have a TFE workspace with it.