### PR TITLE
search for stack, fleet and image builder by name instead of listing all

### DIFF
--- a/appstream/resource_fleet.go
+++ b/appstream/resource_fleet.go
@@ -337,7 +337,12 @@ func resourceAppstreamFleetCreate(d *schema.ResourceData, meta interface{}) erro
 func resourceAppstreamFleetRead(d *schema.ResourceData, meta interface{}) error {
 	svc := meta.(*AWSClient).appstreamconn
 
-	resp, err := svc.DescribeFleets(&appstream.DescribeFleetsInput{})
+	var names []*string
+	fleetName := d.Id()
+	names = append(names, &fleetName)
+	describeFleetsInput := appstream.DescribeFleetsInput{Names: names}
+
+	resp, err := svc.DescribeFleets(&describeFleetsInput)
 
 	if err != nil {
 		log.Printf("[ERROR] Error reading Appstream Fleet: %s", err)

--- a/appstream/resource_image_builder.go
+++ b/appstream/resource_image_builder.go
@@ -211,7 +211,12 @@ func resourceAppstreamImageBuilderRead(d *schema.ResourceData, meta interface{})
 
 	svc := meta.(*AWSClient).appstreamconn
 
-    resp, err := svc.DescribeImageBuilders(&appstream.DescribeImageBuildersInput{})
+	var names []*string
+	imageBuilderName := d.Id()
+	names = append(names, &imageBuilderName)
+	describeImageBuildersInput := appstream.DescribeImageBuildersInput{Names: names}
+
+    resp, err := svc.DescribeImageBuilders(&describeImageBuildersInput)
     if err != nil {
         log.Printf("[ERROR] Error describing Appstream Image Builder: %s", err)
         return err

--- a/appstream/resource_stack.go
+++ b/appstream/resource_stack.go
@@ -183,7 +183,12 @@ func resourceAppstreamStackRead(d *schema.ResourceData, meta interface{}) error 
 
 	svc := meta.(*AWSClient).appstreamconn
 
-	resp, err := svc.DescribeStacks(&appstream.DescribeStacksInput{})
+	var names []*string
+	stackName := d.Id()
+	names = append(names, &stackName)
+	describeStacksInput := appstream.DescribeStacksInput{Names: names}
+
+	resp, err := svc.DescribeStacks(&describeStacksInput)
 	if err != nil {
 		log.Printf("[ERROR] Error describing stacks: %s", err)
 		return err


### PR DESCRIPTION
- this will ensure that in accounts that have many stacks, fleets or image builders, we will not hit the max item limit and return indicating that the item does not exist